### PR TITLE
:new: Add possibility to validate json payload through jsonSchema

### DIFF
--- a/InvalidPayload.php
+++ b/InvalidPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rezzza\SymfonyRestApiJson;
+
+class InvalidPayload extends \Exception
+{
+    private $errors;
+
+    public static function withErrors($payload, $schema, array $errors)
+    {
+        $exception = new static(
+            sprintf('Payload "%s" does not validate the schema "%s". %s errors found.', $payload, $schema, count($errors))
+        );
+        $exception->errors = $errors;
+
+        return $exception;
+    }
+
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/JsonBodyListener.php
+++ b/JsonBodyListener.php
@@ -11,6 +11,13 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class JsonBodyListener
 {
+    private $payloadValidator;
+
+    public function __construct(PayloadValidator $payloadValidator)
+    {
+        $this->payloadValidator = $payloadValidator;
+    }
+
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
@@ -39,6 +46,11 @@ class JsonBodyListener
 
             if (!is_array($data)) {
                 throw new BadRequestHttpException('Invalid ' . $format . ' message received');
+            }
+
+            $jsonSchema = $request->get('_jsonSchema');
+            if (is_array($jsonSchema) && array_key_exists('request', $jsonSchema)) {
+                $this->payloadValidator->validate($content, $jsonSchema['request']);
             }
 
             $request->request = new ParameterBag($data);

--- a/PayloadValidator.php
+++ b/PayloadValidator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rezzza\SymfonyRestApiJson;
+
+use JsonSchema\Validator;
+use JsonSchema\RefResolver;
+
+class PayloadValidator
+{
+    private $delegateValidator;
+
+    private $refResolver;
+
+    public function __construct(Validator $delegateValidator, RefResolver $refResolver)
+    {
+        $this->delegateValidator = $delegateValidator;
+        $this->refResolver = $refResolver;
+    }
+
+    public function validate($payload, $jsonSchemaFilename)
+    {
+        if (false === file_exists($jsonSchemaFilename)) {
+            throw new \UnexpectedValueException(sprintf('Cannot validate payload through "%s" json schema. File does not exist.', $jsonSchemaFilename));
+        }
+
+        $this->delegateValidator->check(
+            $payload,
+            $this->refResolver->resolve('file://' . realpath($jsonSchemaFilename))
+        );
+
+        if (!$this->delegateValidator->isValid()) {
+            throw InvalidPayload::withErrors($payload, $jsonSchemaFilename, $this->delegateValidator->getErrors());
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "symfony/http-kernel": "^2.8|^3.0",
         "symfony/http-foundation": "^2.8|^3.0",
         "symfony/debug": "^2.8|^3.0",
-        "jakeasmith/http_build_url": "^1.0"
+        "jakeasmith/http_build_url": "^1.0",
+        "justinrainbow/json-schema": "^2.0"
     },
     "require-dev": {
         "atoum/atoum": "^2.6",

--- a/tests/Fixtures/mySchema.json
+++ b/tests/Fixtures/mySchema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "min": {
+            "type": "number",
+            "minimum": 0
+        },
+        "max": {
+            "type": "number",
+            "minimum": 0
+        }
+    },
+    "required": [
+        "min",
+        "max"
+    ]
+}

--- a/tests/Units/PayloadValidator.php
+++ b/tests/Units/PayloadValidator.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Rezzza\SymfonyRestApiJson\Tests\Units;
+
+use mageekguy\atoum;
+
+class PayloadValidator extends atoum
+{
+    public function test_validation_should_be_delegated_to_internal_validator()
+    {
+        $this
+            ->given(
+                $validator = $this->mockJsonSchemaValidator(),
+                $this->calling($validator)->check = null,
+                $refResolver = $this->mockJsonSchemaRefResolver(),
+                $this->calling($refResolver)->resolve = 'resolvedJsonSchema',
+                $this->newTestedInstance($validator, $refResolver)
+            )
+            ->when(
+                $this->testedInstance->validate('{"json"}', __DIR__.'/../Fixtures/mySchema.json')
+            )
+            ->then
+                ->mock($validator)
+                    ->call('check')
+                    ->withArguments('{"json"}', 'resolvedJsonSchema')
+                    ->once()
+        ;
+    }
+
+    public function test_unknown_json_schema_lead_to_exception()
+    {
+        $this
+            ->given(
+                $this->newTestedInstance($this->mockJsonSchemaValidator(), $this->mockJsonSchemaRefResolver())
+            )
+            ->exception(function () {
+                $this->testedInstance->validate('{"json"}', 'hello.json');
+            })
+                ->isInstanceOf(\UnexpectedValueException::class)
+        ;
+    }
+
+    public function test_invalid_internal_validation_lead_to_exception()
+    {
+        $this
+            ->given(
+                $validator = $this->mockJsonSchemaValidator(),
+                $this->calling($validator)->check = null,
+                $this->calling($validator)->isValid = false,
+                $this->calling($validator)->getErrors = ['error1', 'error2'],
+                $refResolver = $this->mockJsonSchemaRefResolver(),
+                $this->calling($refResolver)->resolve = 'resolvedJsonSchema',
+                $this->newTestedInstance($validator, $refResolver)
+            )
+            ->exception(function () {
+                $this->testedInstance->validate('{"json"}', __DIR__.'/../Fixtures/mySchema.json');
+            })
+                ->isInstanceOf(\Rezzza\SymfonyRestApiJson\InvalidPayload::class)
+                ->phpArray($this->exception->getErrors())
+                    ->isEqualTo(['error1', 'error2'])
+        ;
+    }
+
+    private function mockJsonSchemaValidator()
+    {
+        $this->mockGenerator->orphanize('__construct');
+
+        return new \mock\JsonSchema\Validator;
+    }
+
+    private function mockJsonSchemaRefResolver()
+    {
+        $this->mockGenerator->orphanize('__construct');
+
+        return new \mock\JsonSchema\RefResolver;
+    }
+}


### PR DESCRIPTION
JsonSchema should be provided in route like

```
hotel_register:
    path: /hotels
    defaults:
        _controller: ui.controller.hotel_controller:postHotelAction,
        _jsonSchema: { request: jsonSchema/hotel_register.json }
    methods: [POST]
```
