### PR TITLE
:bug: Fix request content check edge case

### DIFF
--- a/src/JsonBodyListener.php
+++ b/src/JsonBodyListener.php
@@ -21,16 +21,11 @@ class JsonBodyListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        $method = $request->getMethod();
-
-        if (count($request->request->all())
-            || !in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE', 'LINK', 'UNLINK'])
-        ) {
+        if (!in_array($request->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE', 'LINK', 'UNLINK'])) {
             return;
         }
 
         $contentType = $request->headers->get('Content-Type');
-
         $format = null === $contentType
             ? $request->getRequestFormat()
             : $request->getFormat($contentType);
@@ -40,20 +35,20 @@ class JsonBodyListener
         }
 
         $content = $request->getContent();
-
-        if (!empty($content)) {
-            $data = @json_decode($content, true);
-
-            if (!is_array($data)) {
-                throw new BadRequestHttpException('Invalid ' . $format . ' message received');
-            }
-
-            $jsonSchema = $request->get('_jsonSchema');
-            if (is_array($jsonSchema) && array_key_exists('request', $jsonSchema)) {
-                $this->payloadValidator->validate($content, $jsonSchema['request']);
-            }
-
-            $request->request = new ParameterBag($data);
+        if (empty($content)) {
+            return;
         }
+
+        $data = @json_decode($content, true);
+        if (!is_array($data)) {
+            throw new BadRequestHttpException('Invalid ' . $format . ' message received');
+        }
+
+        $jsonSchema = $request->get('_jsonSchema');
+        if (is_array($jsonSchema) && array_key_exists('request', $jsonSchema)) {
+            $this->payloadValidator->validate($content, $jsonSchema['request']);
+        }
+
+        $request->request = new ParameterBag($data);
     }
 }


### PR DESCRIPTION
Looks like ->request->all() (parameter bag) was returning a non empty parameter bag (with content copied inside it for example).

That's no more the case with recent symfony releases.

So, checking the real content of the request body instead as it should have been done.